### PR TITLE
Change behavior to allow python -m calls

### DIFF
--- a/staticjinja/__main__.py
+++ b/staticjinja/__main__.py
@@ -1,10 +1,6 @@
 #!/usr/bin/env python
 
-import os
-
-from .staticjinja import Site
+from .cli import main
 
 if __name__ == "__main__":
-    searchpath = os.path.join(os.getcwd(), "templates")
-    site = Site.make_site(searchpath=searchpath)
-    site.render(use_reloader=True)
+    main()


### PR DESCRIPTION
The previous behavior didn't allow for CLI parameters to be passed to the code, thus calling python -m staticjinja build --outpath some_folder didn't work as expected.